### PR TITLE
Fix wording of instructions

### DIFF
--- a/story.json
+++ b/story.json
@@ -2,7 +2,7 @@
   {
     "type": "instruction",
     "title": "How to play",
-    "text": "Parity is a numbers puzzle game.\nThe aim of the game is to get each number on the a 3x3 board of numbers to be exactly the same.",
+    "text": "Parity is a numbers puzzle game.\nThe aim of the game is to get each number on a 3x3 board of numbers to be exactly the same.",
     "button": "okay..."
   },
   {


### PR DESCRIPTION
There is a minor typo in the instructions: "the a".  It should be either "the" or "a".  I've picked "a" for this pull request.